### PR TITLE
allow debouncing the onResize callback

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -77,7 +77,7 @@ export default class AutoSizer extends React.PureComponent<Props, State> {
       this._autoSizer.parentNode.ownerDocument &&
       this._autoSizer.parentNode.ownerDocument.defaultView &&
       this._autoSizer.parentNode instanceof
-        this._autoSizer.parentNode.ownerDocument.defaultView.HTMLElement
+      this._autoSizer.parentNode.ownerDocument.defaultView.HTMLElement
     ) {
       // Delay access of parentNode until mount.
       // This handles edge-cases where the component has already been unmounted before its ref has been set,
@@ -97,6 +97,9 @@ export default class AutoSizer extends React.PureComponent<Props, State> {
   }
 
   componentWillUnmount() {
+    if (this.debounceTimeout) {
+      window.clearTimeout(this.debounceTimeout);
+    }
     if (this._detectElementResize && this._parentNode) {
       this._detectElementResize.removeResizeListener(
         this._parentNode,

--- a/src/index.js
+++ b/src/index.js
@@ -33,6 +33,9 @@ type Props = {
   /** Callback to be invoked on-resize */
   onResize: Size => void,
 
+  /** Number of milliseconds to wait before triggering a resize */
+  debounce ?: number,
+
   /** Optional inline style */
   style: ?Object,
 };
@@ -152,6 +155,20 @@ export default class AutoSizer extends React.PureComponent<Props, State> {
   }
 
   _onResize = () => {
+    const {debounce} = this.props;
+    if (debounce === undefined) {
+      this._doOnResize();
+    }
+    else {
+      if (this.debounceTimeout) {
+        window.clearTimeout(this.debounceTimeout);
+      }
+      this.debounceTimeout = window.setTimeout(this._doOnResize, debounce);
+    }
+  }
+
+  _doOnResize = () => {
+    this.debounceTimeout = null;
     const {disableHeight, disableWidth, onResize} = this.props;
 
     if (this._parentNode) {


### PR DESCRIPTION
Currently every time the Autosizer detects a resize operation, it immediately rerenders.

However there are use cases where this is not wanted: for example if we have an animation that as an effect is resizing a panel on which the autosizer is listening on, the autosizer will rerender continuosly and the performance will take a hit (and the animation will likely look slow/lagging).

This PR introduce a debounce optional number prop that represents the number of milliseconds to wait before triggering an update.
If we receive multiple resize during this interval, the interval will be reset and only trigger the update once when no request has been received within the set amount of milliseconds.