### PR TITLE
Added prop setWidthOnContainer to set width on containing div

### DIFF
--- a/src/__tests__/AutoSizer.js
+++ b/src/__tests__/AutoSizer.js
@@ -42,6 +42,7 @@ describe('AutoSizer', () => {
     defaultWidth = undefined,
     disableHeight = false,
     disableWidth = false,
+    setWidthOnContainer = false,
     foo = 456,
     height = 100,
     onResize,
@@ -72,6 +73,7 @@ describe('AutoSizer', () => {
           defaultWidth={defaultWidth}
           disableHeight={disableHeight}
           disableWidth={disableWidth}
+          setWidthOnContainer={setWidthOnContainer}
           onResize={onResize}
           style={style}>
           {({height, width}) => (
@@ -129,6 +131,7 @@ describe('AutoSizer', () => {
 
   it('should not update :width if :disableWidth is true', () => {
     const rendered = findDOMNode(render(getMarkup({disableWidth: true})));
+    expect(rendered.style.width).toEqual('200px');
     expect(rendered.textContent).toContain('height:100');
     expect(rendered.textContent).toContain('width:undefined');
   });
@@ -138,6 +141,20 @@ describe('AutoSizer', () => {
     expect(rendered.textContent).toContain('height:undefined');
     expect(rendered.textContent).toContain('width:200');
   });
+
+  it('should set width on container if :setWidthOnContainer is false', () => {
+    const rendered = findDOMNode(render(getMarkup({ setWidthOnContainer: false })));
+    expect(rendered.children["0"].style.width).toEqual('0px');
+    expect(rendered.textContent).toContain('height:100');
+    expect(rendered.textContent).toContain('width:200');
+  })
+
+  it('should set width on container if :setWidthOnContainer is true', () => {
+    const rendered = findDOMNode(render(getMarkup({ setWidthOnContainer: true })));
+    expect(rendered.children["0"].style.width).toEqual('200px');
+    expect(rendered.textContent).toContain('height:100');
+    expect(rendered.textContent).toContain('width:200');
+  })
 
   async function simulateResize({element, height, width}) {
     mockOffsetSize(width, height);

--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,9 @@ type Props = {
   /** Disable dynamic :width property */
   disableWidth: boolean,
 
+  /** Enable setting width on containing div, to allow horizontal scrolling */
+  setWidthOnContainer: boolean,
+
   /** Nonce of the inlined stylesheet for Content Security Policy */
   nonce?: string,
 
@@ -54,6 +57,7 @@ export default class AutoSizer extends React.PureComponent<Props, State> {
     onResize: () => {},
     disableHeight: false,
     disableWidth: false,
+    setWidthOnContainer: false,
     style: {},
   };
 
@@ -108,6 +112,7 @@ export default class AutoSizer extends React.PureComponent<Props, State> {
       className,
       disableHeight,
       disableWidth,
+      setWidthOnContainer,
       style,
     } = this.props;
     const {height, width} = this.state;
@@ -134,7 +139,7 @@ export default class AutoSizer extends React.PureComponent<Props, State> {
       if (width === 0) {
         bailoutOnChildren = true;
       }
-      outerStyle.width = 0;
+      outerStyle.width = setWidthOnContainer ? width : 0;
       childParams.width = width;
     }
 


### PR DESCRIPTION
This is to allow the child component to have its visible width set, and allow horizontal scrolling of the child component if its rendered size is bigger than its visible size.