### PR TITLE
Add an extra check for an e.target.className.indexOf function

### DIFF
--- a/src/vendor/detectElementResize.js
+++ b/src/vendor/detectElementResize.js
@@ -71,6 +71,8 @@ export default function createDetectElementResize(nonce) {
     var scrollListener = function(e) {
       // Don't measure (which forces) reflow for scrolls that happen inside of children!
       if (
+        e.target.className &&
+        typeof e.target.className.indexOf === 'function' &&
         e.target.className.indexOf('contract-trigger') < 0 &&
         e.target.className.indexOf('expand-trigger') < 0
       ) {


### PR DESCRIPTION
This PR pulls in the fix from bvaughn/react-virtualized#1210.

className is null when the element has no classes. I had encountered the null-reference error here because react-map-gl uses this standalone library.