### PR TITLE
Consider floating point widths and heights of parent node

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -159,8 +159,9 @@ export default class AutoSizer extends React.PureComponent<Props, State> {
       // This can result in invalid style values which can result in NaN values if we don't handle them.
       // See issue #150 for more context.
 
-      const height = this._parentNode.offsetHeight || 0;
-      const width = this._parentNode.offsetWidth || 0;
+      const rect = this._parentNode.getBoundingClientRect();
+      const height = rect.height || 0;
+      const width = rect.width || 0;
 
       const style = window.getComputedStyle(this._parentNode) || {};
       const paddingLeft = parseInt(style.paddingLeft, 10) || 0;


### PR DESCRIPTION
In some cases (like having a dynamic grid layout on the page) parent nodes have floating point widths and heights. `offsetWidth` and `offsetHeight` does not consider this, it just delivers integers. This results in wrong layouting. `getBoundingClientRect` considers floating point values, and therefore fixes the wrong layouting.

Sidenote: According to some research i've done, `getBoundingClientRect` returns the same values for `width` and `height` as `offsetWidth` and `offsetHeight`, except for the case when a parent node uses `transform: scale(...)`.
