### PR TITLE
Create Trusted Type policy for assigning an HTML in detectElementResize.js

### DIFF
--- a/src/vendor/detectElementResize.js
+++ b/src/vendor/detectElementResize.js
@@ -176,9 +176,18 @@ export default function createDetectElementResize(nonce) {
         element.__resizeListeners__ = [];
         (element.__resizeTriggers__ = doc.createElement('div')).className =
           'resize-triggers';
-        element.__resizeTriggers__.innerHTML =
+        var resizeTriggersHtml =
           '<div class="expand-trigger"><div></div></div>' +
           '<div class="contract-trigger"></div>';
+        if (window.trustedTypes) {
+          var staticPolicy = trustedTypes.createPolicy(
+            'react-virtualized-auto-sizer',
+            {createHTML: () => resizeTriggersHtml},
+          );
+          element.__resizeTriggers__.innerHTML = staticPolicy.createHTML('');
+        } else {
+          element.__resizeTriggers__.innerHTML = resizeTriggersHtml;
+        }
         element.appendChild(element.__resizeTriggers__);
         resetTriggers(element);
         element.addEventListener('scroll', scrollListener, true);


### PR DESCRIPTION
When react-virtualized-auto-sizer is used in a page where it enforces [Trusted Types](https://web.dev/trusted-types/), Trusted Types violation will trigger because there is an `innerHTML` usage in `detectElementResize.js`.

I have made a fix to create a Trusted Type policy that returns the same HTML to eliminate this Trusted Types violation.

This change is cherrypicked from https://github.com/bvaughn/react-virtualized/pull/1614