### PR TITLE
Spread props onto div

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -145,7 +145,8 @@ export default class AutoSizer extends React.PureComponent<Props, State> {
         style={{
           ...outerStyle,
           ...style,
-        }}>
+        }}
+        {...this.props}>
         {!bailoutOnChildren && children(childParams)}
       </div>
     );


### PR DESCRIPTION
This allows users of the libraray to pass a tabIndex prop to avoid a11y accessibility guidance violations.
https://dequeuniversity.com/rules/axe/4.1/scrollable-region-focusable?application=axeAPI