### PR TITLE
Fixed rAF throttling issue caused by new Chrome flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,10 @@
 {
   "name": "react-virtualized-auto-sizer",
   "version": "1.0.5",
-  "description": "Standalone version of the AutoSizer component from react-virtualized",
-  "author": "Brian Vaughn <brian.david.vaughn@gmail.com> (https://github.com/bvaughn/)",
+  "description":
+    "Standalone version of the AutoSizer component from react-virtualized",
+  "author":
+    "Brian Vaughn <brian.david.vaughn@gmail.com> (https://github.com/bvaughn/)",
   "contributors": [
     "Brian Vaughn <brian.david.vaughn@gmail.com> (https://github.com/bvaughn/)"
   ],
@@ -34,9 +36,7 @@
   ],
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
-  "files": [
-    "dist/*"
-  ],
+  "files": ["dist/*"],
   "scripts": {
     "precommit": "lint-staged",
     "prettier": "prettier --write '**/*.{js,json,css}'",
@@ -51,10 +51,7 @@
     "deploy": "gh-pages -d example/build"
   },
   "lint-staged": {
-    "{example,src}/**/*.{js,json,css}": [
-      "prettier --write",
-      "git add"
-    ],
+    "{example,src}/**/*.{js,json,css}": ["prettier --write", "git add"],
     "**/*.js": "eslint --max-warnings 0"
   },
   "peerDependencies": {

--- a/src/__tests__/AutoSizer.js
+++ b/src/__tests__/AutoSizer.js
@@ -1,7 +1,7 @@
 /* global Element, Event */
 
 import * as React from 'react';
-import ReactDOM, {findDOMNode} from 'react-dom';
+import ReactDOM, { findDOMNode } from 'react-dom';
 import AutoSizer from '../index';
 
 function render(markup) {
@@ -27,7 +27,7 @@ render.unmount = function() {
   }
 };
 
-function DefaultChildComponent({height, width, foo, bar}) {
+function DefaultChildComponent({ height, width, foo, bar }) {
   return (
     <div>{`width:${width}, height:${height}, foo:${foo}, bar:${bar}`}</div>
   );
@@ -73,8 +73,9 @@ describe('AutoSizer', () => {
           disableHeight={disableHeight}
           disableWidth={disableWidth}
           onResize={onResize}
-          style={style}>
-          {({height, width}) => (
+          style={style}
+        >
+          {({ height, width }) => (
             <ChildComponent
               width={disableWidth ? undefined : width}
               height={disableHeight ? undefined : height}
@@ -120,26 +121,26 @@ describe('AutoSizer', () => {
           paddingLeft: 4,
           paddingRight: 4,
           paddingTop: 15,
-        }),
-      ),
+        })
+      )
     );
     expect(rendered.textContent).toContain('height:75');
     expect(rendered.textContent).toContain('width:192');
   });
 
   it('should not update :width if :disableWidth is true', () => {
-    const rendered = findDOMNode(render(getMarkup({disableWidth: true})));
+    const rendered = findDOMNode(render(getMarkup({ disableWidth: true })));
     expect(rendered.textContent).toContain('height:100');
     expect(rendered.textContent).toContain('width:undefined');
   });
 
   it('should not update :height if :disableHeight is true', () => {
-    const rendered = findDOMNode(render(getMarkup({disableHeight: true})));
+    const rendered = findDOMNode(render(getMarkup({ disableHeight: true })));
     expect(rendered.textContent).toContain('height:undefined');
     expect(rendered.textContent).toContain('width:200');
   });
 
-  async function simulateResize({element, height, width}) {
+  async function simulateResize({ element, height, width }) {
     mockOffsetSize(width, height);
 
     // Trigger detectElementResize library by faking a scroll event
@@ -157,12 +158,12 @@ describe('AutoSizer', () => {
         getMarkup({
           height: 100,
           width: 200,
-        }),
-      ),
+        })
+      )
     );
     expect(rendered.textContent).toContain('height:100');
     expect(rendered.textContent).toContain('width:200');
-    await simulateResize({element: rendered, height: 400, width: 300});
+    await simulateResize({ element: rendered, height: 400, width: 300 });
     expect(rendered.textContent).toContain('height:400');
     expect(rendered.textContent).toContain('width:300');
     done();
@@ -181,12 +182,12 @@ describe('AutoSizer', () => {
             height: 100,
             onResize,
             width: 200,
-          }),
-        ),
+          })
+        )
       );
       ChildComponent.mockClear(); // TODO Improve initial check in version 10; see AutoSizer render()
       expect(onResize).toHaveBeenCalledTimes(1);
-      await simulateResize({element: rendered, height: 400, width: 300});
+      await simulateResize({ element: rendered, height: 400, width: 300 });
       expect(ChildComponent).toHaveBeenCalledTimes(1);
       expect(onResize).toHaveBeenCalledTimes(2);
       done();
@@ -205,15 +206,15 @@ describe('AutoSizer', () => {
             height: 100,
             onResize,
             width: 200,
-          }),
-        ),
+          })
+        )
       );
       ChildComponent.mockClear(); // TODO Improve initial check in version 10; see AutoSizer render()
       expect(onResize).toHaveBeenCalledTimes(1);
-      await simulateResize({element: rendered, height: 100, width: 300});
+      await simulateResize({ element: rendered, height: 100, width: 300 });
       expect(ChildComponent).toHaveBeenCalledTimes(0);
       expect(onResize).toHaveBeenCalledTimes(1);
-      await simulateResize({element: rendered, height: 200, width: 300});
+      await simulateResize({ element: rendered, height: 200, width: 300 });
       expect(ChildComponent).toHaveBeenCalledTimes(1);
       expect(onResize).toHaveBeenCalledTimes(2);
       done();
@@ -232,15 +233,15 @@ describe('AutoSizer', () => {
             height: 100,
             onResize,
             width: 200,
-          }),
-        ),
+          })
+        )
       );
       ChildComponent.mockClear(); // TODO Improve initial check in version 10; see AutoSizer render()
       expect(onResize).toHaveBeenCalledTimes(1);
-      await simulateResize({element: rendered, height: 200, width: 200});
+      await simulateResize({ element: rendered, height: 200, width: 200 });
       expect(ChildComponent).toHaveBeenCalledTimes(0);
       expect(onResize).toHaveBeenCalledTimes(1);
-      await simulateResize({element: rendered, height: 200, width: 300});
+      await simulateResize({ element: rendered, height: 200, width: 300 });
       expect(ChildComponent).toHaveBeenCalledTimes(1);
       expect(onResize).toHaveBeenCalledTimes(2);
       done();
@@ -249,13 +250,13 @@ describe('AutoSizer', () => {
 
   describe('className and style', () => {
     it('should use a custom :className if specified', () => {
-      const rendered = findDOMNode(render(getMarkup({className: 'foo'})));
+      const rendered = findDOMNode(render(getMarkup({ className: 'foo' })));
       expect(rendered.firstChild.className).toContain('foo');
     });
 
     it('should use a custom :style if specified', () => {
-      const style = {backgroundColor: 'red'};
-      const rendered = findDOMNode(render(getMarkup({style})));
+      const style = { backgroundColor: 'red' };
+      const rendered = findDOMNode(render(getMarkup({ style })));
       expect(rendered.firstChild.style.backgroundColor).toEqual('red');
     });
   });

--- a/src/__tests__/AutoSizer.ssr.js
+++ b/src/__tests__/AutoSizer.ssr.js
@@ -3,14 +3,14 @@
  */
 
 import React from 'react';
-import {renderToString} from 'react-dom/server';
+import { renderToString } from 'react-dom/server';
 import AutoSizer from '../index';
 
 test('should render content with default widths and heights initially', () => {
   const rendered = renderToString(
     <AutoSizer defaultHeight={100} defaultWidth={200}>
-      {({height, width}) => <div>{`height:${height};width:${width}`}</div>}
-    </AutoSizer>,
+      {({ height, width }) => <div>{`height:${height};width:${width}`}</div>}
+    </AutoSizer>
   );
   expect(rendered).toContain('height:100');
   expect(rendered).toContain('width:200');

--- a/src/index.js
+++ b/src/index.js
@@ -67,7 +67,7 @@ export default class AutoSizer extends React.PureComponent<Props, State> {
   _detectElementResize: DetectElementResize;
 
   componentDidMount() {
-    const {nonce} = this.props;
+    const { nonce } = this.props;
     if (
       this._autoSizer &&
       this._autoSizer.parentNode &&
@@ -86,7 +86,7 @@ export default class AutoSizer extends React.PureComponent<Props, State> {
       this._detectElementResize = createDetectElementResize(nonce);
       this._detectElementResize.addResizeListener(
         this._parentNode,
-        this._onResize,
+        this._onResize
       );
 
       this._onResize();
@@ -97,7 +97,7 @@ export default class AutoSizer extends React.PureComponent<Props, State> {
     if (this._detectElementResize && this._parentNode) {
       this._detectElementResize.removeResizeListener(
         this._parentNode,
-        this._onResize,
+        this._onResize
       );
     }
   }
@@ -110,12 +110,12 @@ export default class AutoSizer extends React.PureComponent<Props, State> {
       disableWidth,
       style,
     } = this.props;
-    const {height, width} = this.state;
+    const { height, width } = this.state;
 
     // Outer div should not force width/height since that may prevent containers from shrinking.
     // Inner component should overflow and use calculated width/height.
     // See issue #68 for more information.
-    const outerStyle: Object = {overflow: 'visible'};
+    const outerStyle: Object = { overflow: 'visible' };
     const childParams: Object = {};
 
     // Avoid rendering children before the initial measurements have been collected.
@@ -145,14 +145,15 @@ export default class AutoSizer extends React.PureComponent<Props, State> {
         style={{
           ...outerStyle,
           ...style,
-        }}>
+        }}
+      >
         {!bailoutOnChildren && children(childParams)}
       </div>
     );
   }
 
   _onResize = () => {
-    const {disableHeight, disableWidth, onResize} = this.props;
+    const { disableHeight, disableWidth, onResize } = this.props;
 
     if (this._parentNode) {
       // Guard against AutoSizer component being removed from the DOM immediately after being added.
@@ -180,7 +181,7 @@ export default class AutoSizer extends React.PureComponent<Props, State> {
           width: width - paddingLeft - paddingRight,
         });
 
-        onResize({height, width});
+        onResize({ height, width });
       }
     }
   };

--- a/src/vendor/detectElementResize.js
+++ b/src/vendor/detectElementResize.js
@@ -10,46 +10,84 @@
  * 4) Add nonce for style element.
  **/
 
+// Check `document` and `window` in case of server-side rendering
+let windowObject;
+if (typeof window !== 'undefined') {
+  windowObject = window;
+
+  // eslint-disable-next-line no-restricted-globals
+} else if (typeof self !== 'undefined') {
+  // eslint-disable-next-line no-restricted-globals
+  windowObject = self;
+} else {
+  windowObject = global;
+}
+
+let cancelFrame = null;
+let requestFrame = null;
+
+const TIMEOUT_DURATION = 20;
+
+const clearTimeoutFn = windowObject.clearTimeout;
+const setTimeoutFn = windowObject.setTimeout;
+
+const cancelAnimationFrameFn =
+  windowObject.cancelAnimationFrame ||
+  windowObject.mozCancelAnimationFrame ||
+  windowObject.webkitCancelAnimationFrame;
+
+const requestAnimationFrameFn =
+  windowObject.requestAnimationFrame ||
+  windowObject.mozRequestAnimationFrame ||
+  windowObject.webkitRequestAnimationFrame;
+
+if (cancelAnimationFrameFn == null || requestAnimationFrameFn == null) {
+  // For environments that don't support animation frame,
+  // fallback to a setTimeout based approach.
+  cancelFrame = clearTimeoutFn;
+  requestFrame = function requestAnimationFrameViaSetTimeout(callback) {
+    return setTimeoutFn(callback, TIMEOUT_DURATION);
+  };
+} else {
+  // Counter intuitively, environments that support animation frames can be trickier.
+  // Chrome's "Throttle non-visible cross-origin iframes" flag can prevent rAFs from being called.
+  // In this case, we should fallback to a setTimeout() implementation.
+  cancelFrame = function cancelFrame([animationFrameID, timeoutID]) {
+    cancelAnimationFrameFn(animationFrameID);
+    clearTimeoutFn(timeoutID);
+  };
+  requestFrame = function requestAnimationFrameWithSetTimeoutFallback(
+    callback
+  ) {
+    const animationFrameID = requestAnimationFrameFn(
+      function animationFrameCallback() {
+        clearTimeoutFn(timeoutID);
+        callback();
+      }
+    );
+
+    const timeoutID = setTimeoutFn(function timeoutCallback() {
+      cancelAnimationFrameFn(animationFrameID);
+      callback();
+    }, TIMEOUT_DURATION);
+
+    return [animationFrameID, timeoutID];
+  };
+}
+
 export default function createDetectElementResize(nonce) {
-  // Check `document` and `window` in case of server-side rendering
-  var _window;
-  if (typeof window !== 'undefined') {
-    _window = window;
-  } else if (typeof self !== 'undefined') {
-    _window = self;
-  } else {
-    _window = global;
-  }
+  let animationKeyframes;
+  let animationName;
+  let animationStartEvent;
+  let animationStyle;
+  let checkTriggers;
+  let resetTriggers;
+  let scrollListener;
 
-  var attachEvent = typeof document !== 'undefined' && document.attachEvent;
-
+  const attachEvent = typeof document !== 'undefined' && document.attachEvent;
   if (!attachEvent) {
-    var requestFrame = (function() {
-      var raf =
-        _window.requestAnimationFrame ||
-        _window.mozRequestAnimationFrame ||
-        _window.webkitRequestAnimationFrame ||
-        function(fn) {
-          return _window.setTimeout(fn, 20);
-        };
-      return function(fn) {
-        return raf(fn);
-      };
-    })();
-
-    var cancelFrame = (function() {
-      var cancel =
-        _window.cancelAnimationFrame ||
-        _window.mozCancelAnimationFrame ||
-        _window.webkitCancelAnimationFrame ||
-        _window.clearTimeout;
-      return function(id) {
-        return cancel(id);
-      };
-    })();
-
-    var resetTriggers = function(element) {
-      var triggers = element.__resizeTriggers__,
+    resetTriggers = function(element) {
+      const triggers = element.__resizeTriggers__,
         expand = triggers.firstElementChild,
         contract = triggers.lastElementChild,
         expandChild = expand.firstElementChild;
@@ -61,14 +99,14 @@ export default function createDetectElementResize(nonce) {
       expand.scrollTop = expand.scrollHeight;
     };
 
-    var checkTriggers = function(element) {
+    checkTriggers = function(element) {
       return (
-        element.offsetWidth != element.__resizeLast__.width ||
-        element.offsetHeight != element.__resizeLast__.height
+        element.offsetWidth !== element.__resizeLast__.width ||
+        element.offsetHeight !== element.__resizeLast__.height
       );
     };
 
-    var scrollListener = function(e) {
+    scrollListener = function(e) {
       // Don't measure (which forces) reflow for scrolls that happen inside of children!
       if (
         e.target.className &&
@@ -79,16 +117,18 @@ export default function createDetectElementResize(nonce) {
         return;
       }
 
-      var element = this;
+      const element = this;
       resetTriggers(this);
       if (this.__resizeRAF__) {
         cancelFrame(this.__resizeRAF__);
       }
-      this.__resizeRAF__ = requestFrame(function() {
+      this.__resizeRAF__ = requestFrame(function animationFrame() {
         if (checkTriggers(element)) {
           element.__resizeLast__.width = element.offsetWidth;
           element.__resizeLast__.height = element.offsetHeight;
-          element.__resizeListeners__.forEach(function(fn) {
+          element.__resizeListeners__.forEach(function forEachResizeListener(
+            fn
+          ) {
             fn.call(element, e);
           });
         }
@@ -96,26 +136,26 @@ export default function createDetectElementResize(nonce) {
     };
 
     /* Detect CSS Animations support to detect element display/re-attach */
-    var animation = false,
-      keyframeprefix = '',
-      animationstartevent = 'animationstart',
-      domPrefixes = 'Webkit Moz O ms'.split(' '),
-      startEvents = 'webkitAnimationStart animationstart oAnimationStart MSAnimationStart'.split(
-        ' ',
-      ),
-      pfx = '';
+    let animation = false;
+    let keyframeprefix = '';
+    animationStartEvent = 'animationstart';
+    const domPrefixes = 'Webkit Moz O ms'.split(' ');
+    let startEvents = 'webkitAnimationStart animationstart oAnimationStart MSAnimationStart'.split(
+      ' '
+    );
+    let pfx = '';
     {
-      var elm = document.createElement('fakeelement');
+      const elm = document.createElement('fakeelement');
       if (elm.style.animationName !== undefined) {
         animation = true;
       }
 
       if (animation === false) {
-        for (var i = 0; i < domPrefixes.length; i++) {
+        for (let i = 0; i < domPrefixes.length; i++) {
           if (elm.style[domPrefixes[i] + 'AnimationName'] !== undefined) {
             pfx = domPrefixes[i];
             keyframeprefix = '-' + pfx.toLowerCase() + '-';
-            animationstartevent = startEvents[i];
+            animationStartEvent = startEvents[i];
             animation = true;
             break;
           }
@@ -123,21 +163,20 @@ export default function createDetectElementResize(nonce) {
       }
     }
 
-    var animationName = 'resizeanim';
-    var animationKeyframes =
+    animationName = 'resizeanim';
+    animationKeyframes =
       '@' +
       keyframeprefix +
       'keyframes ' +
       animationName +
       ' { from { opacity: 0; } to { opacity: 0; } } ';
-    var animationStyle =
-      keyframeprefix + 'animation: 1ms ' + animationName + '; ';
+    animationStyle = keyframeprefix + 'animation: 1ms ' + animationName + '; ';
   }
 
-  var createStyles = function(doc) {
+  const createStyles = function(doc) {
     if (!doc.getElementById('detectElementResize')) {
       //opacity:0 works around a chrome bug https://code.google.com/p/chromium/issues/detail?id=286360
-      var css =
+      const css =
           (animationKeyframes ? animationKeyframes : '') +
           '.resize-triggers { ' +
           (animationStyle ? animationStyle : '') +
@@ -163,14 +202,14 @@ export default function createDetectElementResize(nonce) {
     }
   };
 
-  var addResizeListener = function(element, fn) {
+  const addResizeListener = function(element, fn) {
     if (attachEvent) {
       element.attachEvent('onresize', fn);
     } else {
       if (!element.__resizeTriggers__) {
-        var doc = element.ownerDocument;
-        var elementStyle = _window.getComputedStyle(element);
-        if (elementStyle && elementStyle.position == 'static') {
+        const doc = element.ownerDocument;
+        const elementStyle = windowObject.getComputedStyle(element);
+        if (elementStyle && elementStyle.position === 'static') {
           element.style.position = 'relative';
         }
         createStyles(doc);
@@ -178,10 +217,10 @@ export default function createDetectElementResize(nonce) {
         element.__resizeListeners__ = [];
         (element.__resizeTriggers__ = doc.createElement('div')).className =
           'resize-triggers';
-        var expandTrigger = doc.createElement('div');
+        const expandTrigger = doc.createElement('div');
         expandTrigger.className = 'expand-trigger';
         expandTrigger.appendChild(doc.createElement('div'));
-        var contractTrigger = doc.createElement('div');
+        const contractTrigger = doc.createElement('div');
         contractTrigger.className = 'contract-trigger';
         element.__resizeTriggers__.appendChild(expandTrigger);
         element.__resizeTriggers__.appendChild(contractTrigger);
@@ -190,17 +229,17 @@ export default function createDetectElementResize(nonce) {
         element.addEventListener('scroll', scrollListener, true);
 
         /* Listen for a css animation to detect element display/re-attach */
-        if (animationstartevent) {
+        if (animationStartEvent) {
           element.__resizeTriggers__.__animationListener__ = function animationListener(
-            e,
+            e
           ) {
-            if (e.animationName == animationName) {
+            if (e.animationName === animationName) {
               resetTriggers(element);
             }
           };
           element.__resizeTriggers__.addEventListener(
-            animationstartevent,
-            element.__resizeTriggers__.__animationListener__,
+            animationStartEvent,
+            element.__resizeTriggers__.__animationListener__
           );
         }
       }
@@ -208,26 +247,26 @@ export default function createDetectElementResize(nonce) {
     }
   };
 
-  var removeResizeListener = function(element, fn) {
+  const removeResizeListener = function(element, fn) {
     if (attachEvent) {
       element.detachEvent('onresize', fn);
     } else {
       element.__resizeListeners__.splice(
         element.__resizeListeners__.indexOf(fn),
-        1,
+        1
       );
       if (!element.__resizeListeners__.length) {
         element.removeEventListener('scroll', scrollListener, true);
         if (element.__resizeTriggers__.__animationListener__) {
           element.__resizeTriggers__.removeEventListener(
-            animationstartevent,
-            element.__resizeTriggers__.__animationListener__,
+            animationStartEvent,
+            element.__resizeTriggers__.__animationListener__
           );
           element.__resizeTriggers__.__animationListener__ = null;
         }
         try {
           element.__resizeTriggers__ = !element.removeChild(
-            element.__resizeTriggers__,
+            element.__resizeTriggers__
           );
         } catch (e) {
           // Preact compat; see developit/preact-compat/issues/228


### PR DESCRIPTION
Chrome's new "Throttle non-visible cross-origin iframes" flag causes problems for code running inside of hidden iframes. In this case, animation frames get scheduled without any error but never get called. This causes problems for the React DevTools browser extension specifically.

This commit adds a workaround by scheduling a backup timeout along with animation frames. In the normal case, these timeout will be cancelled by the animation frame (which will run first).

For more info, see https://github.com/facebook/react/issues/21986