### PR TITLE
Allow react 18 in peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,8 +55,8 @@
     "**/*.js": "eslint --max-warnings 0"
   },
   "peerDependencies": {
-    "react": "^15.3.0 || ^16.0.0-alpha || ^17.0.0",
-    "react-dom": "^15.3.0 || ^16.0.0-alpha || ^17.0.0"
+    "react": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0",
+    "react-dom": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0"
   },
   "devDependencies": {
     "babel-core": "^6.26.0",


### PR DESCRIPTION
React 18 has been officially released: https://reactjs.org/blog/2022/03/29/react-v18.html