### PR TITLE
fix: correct boolean types

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -18,16 +18,16 @@ type BaseProps = {
 export type HeightOnlyProps = BaseProps & {
   children: (size: VerticalSize) => ReactNode;
   defaultHeight?: number;
-  disableHeight?: false;
-  disableWidth: true;
+  disableHeight?: boolean;
+  disableWidth: boolean;
   onResize?: (size: VerticalSize) => void;
 };
 
 export type WidthOnlyProps = BaseProps & {
   children: (size: HorizontalSize) => ReactNode;
   defaultWidth?: number;
-  disableHeight: true;
-  disableWidth?: false;
+  disableHeight: boolean;
+  disableWidth?: boolean;
   onResize?: (size: HorizontalSize) => void;
 };
 
@@ -35,8 +35,8 @@ export type HeightAndWidthProps = BaseProps & {
   children: (size: Size) => ReactNode;
   defaultHeight?: number;
   defaultWidth?: number;
-  disableHeight?: false;
-  disableWidth?: false;
+  disableHeight?: boolean;
+  disableWidth?: boolean;
   onResize?: (size: Size) => void;
 };
 


### PR DESCRIPTION
Fixes: https://github.com/bvaughn/react-virtualized-auto-sizer/issues/70

Correcting the boolean types, as `true` and `false` aren't valid TypeScript types