### PR TITLE
Handle empty string values on reading parent node style

### DIFF
--- a/src/AutoSizer.ts
+++ b/src/AutoSizer.ts
@@ -157,10 +157,10 @@ export class AutoSizer extends Component<Props, State> {
       // See issue #150 for more context.
 
       const style = window.getComputedStyle(this._parentNode) || {};
-      const paddingLeft = parseFloat(style.paddingLeft ?? "0");
-      const paddingRight = parseFloat(style.paddingRight ?? "0");
-      const paddingTop = parseFloat(style.paddingTop ?? "0");
-      const paddingBottom = parseFloat(style.paddingBottom ?? "0");
+      const paddingLeft = parseFloat(style.paddingLeft || "0");
+      const paddingRight = parseFloat(style.paddingRight || "0");
+      const paddingTop = parseFloat(style.paddingTop || "0");
+      const paddingBottom = parseFloat(style.paddingBottom || "0");
 
       const rect = this._parentNode.getBoundingClientRect();
       const scaledHeight = rect.height - paddingTop - paddingBottom;


### PR DESCRIPTION
When reading the parent node's styles during resize, we can sometimes encounter styles with the value ''. This can happen if the node is removed from the DOM very quickly after mount (window.getComputedStyle returns '' for elements not attached to DOM). This was not handled by null-coalescing, so we need to switch to use falsy check instead.

This appears to be the same issue from https://github.com/bvaughn/react-virtualized/issues/150.

Tests are not included - it looks like our JSDOM version doesn't support empty string values for css properties, as far as I can tell (See https://github.com/jsdom/jsdom/issues/2504 and https://github.com/jsdom/cssstyle/pull/165)

Fixes https://github.com/bvaughn/react-virtualized-auto-sizer/issues/78