### PR TITLE
chore: remove redundant observe call on unmount

### DIFF
--- a/src/AutoSizer.ts
+++ b/src/AutoSizer.ts
@@ -81,7 +81,6 @@ export class AutoSizer extends Component<Props, State> {
       }
 
       if (this._resizeObserver) {
-        this._resizeObserver.observe(this._parentNode);
         this._resizeObserver.disconnect();
       }
     }


### PR DESCRIPTION
This looks like a typo, `unobserve` should be called instead. Since `disconnect` is called right after it, it doesn't really have any effect, so we can remove it.

Reading https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver/disconnect, `disconnect` should unobserve all observed elements.