### PR TITLE
Adds a test checking that we handle empty string styles

### DIFF
--- a/src/AutoSizer.test.tsx
+++ b/src/AutoSizer.test.tsx
@@ -88,6 +88,7 @@ describe("AutoSizer", () => {
       paddingRight = 0,
       paddingTop = 0,
       width = 200,
+      excludeWrapperStyling = false,
     } = {},
     props: Omit<Props, "children"> = {}
   ) {
@@ -110,7 +111,7 @@ describe("AutoSizer", () => {
     const root = createRoot(container);
     act(() => {
       root.render(
-        <div style={wrapperStyle}>
+        <div style={!excludeWrapperStyling ? wrapperStyle : undefined}>
           <AutoSizer
             disableHeight={disableHeight as any}
             disableWidth={disableWidth as any}
@@ -142,6 +143,18 @@ describe("AutoSizer", () => {
 
     expect(container.textContent).toContain("height:100");
     expect(container.textContent).toContain("width:200");
+  });
+
+  it("should not render children for elements with empty computed styles", () => {
+    mockOffsetSize(0, 0);
+
+    renderHelper({
+      excludeWrapperStyling: true,
+      height: 0,
+      width: 0,
+    });
+
+    expect(container.textContent).toEqual("");
   });
 
   it("should account for padding when calculating the available width and height", () => {

--- a/src/AutoSizer.test.tsx
+++ b/src/AutoSizer.test.tsx
@@ -81,6 +81,7 @@ describe("AutoSizer", () => {
     {
       bar = 123,
       ChildComponent = DefaultChildComponent,
+      excludeWrapperStyling = false,
       foo = 456,
       height = 100,
       paddingBottom = 0,
@@ -88,7 +89,6 @@ describe("AutoSizer", () => {
       paddingRight = 0,
       paddingTop = 0,
       width = 200,
-      excludeWrapperStyling = false,
     } = {},
     props: Omit<Props, "children"> = {}
   ) {
@@ -111,7 +111,7 @@ describe("AutoSizer", () => {
     const root = createRoot(container);
     act(() => {
       root.render(
-        <div style={!excludeWrapperStyling ? wrapperStyle : undefined}>
+        <div style={excludeWrapperStyling ? undefined : wrapperStyle}>
           <AutoSizer
             disableHeight={disableHeight as any}
             disableWidth={disableWidth as any}


### PR DESCRIPTION
This adds a test for the fix for https://github.com/bvaughn/react-virtualized-auto-sizer/issues/79 - while that situation can appear in more situations than the one tested here (nodes being detached from the DOM, etc), it at least manifests in our test environment if we don't apply any styling to the parent node.

Relates to https://github.com/bvaughn/react-virtualized-auto-sizer/issues/80, so if there is a decision to change the behavior, there is at least a test of _some_ kind